### PR TITLE
Bugfix: migasfree-tags not found packages.

### DIFF
--- a/migasfree_client/tags.py
+++ b/migasfree_client/tags.py
@@ -173,7 +173,7 @@ class MigasFreeTags(MigasFreeCommand):
         mfc = MigasFreeClient()
 
         # Update metadata
-        mfc._clean_pms_cache()
+        mfc._update_system()
 
         # Remove Packages
         mfc._uninstall_packages(rules["packages"]["remove"])


### PR DESCRIPTION
When we change the tags is necessary generate migasfree.list for new tags.
